### PR TITLE
Newline after parenthesis if two arguments or more

### DIFF
--- a/default.js
+++ b/default.js
@@ -19,7 +19,7 @@ module.exports = {
         "space-unary-ops": ["error", { "words": true, "nonwords": false }],
         "object-property-newline": ["error", { "allowAllPropertiesOnSameLine": true }],
         "space-in-parens": ["error", "never"],
-        "function-paren-newline": ["error", { "minItems": 2 }],
+        "function-paren-newline": ["error", "multiline-arguments"],
         "space-before-blocks": ["warn", "always"],
         "brace-style": ["warn", "1tbs", { "allowSingleLine": true }],
         "object-curly-spacing": ["warn", "always", { "arraysInObjects": false }],

--- a/default.js
+++ b/default.js
@@ -19,6 +19,7 @@ module.exports = {
         "space-unary-ops": ["error", { "words": true, "nonwords": false }],
         "object-property-newline": ["error", { "allowAllPropertiesOnSameLine": true }],
         "space-in-parens": ["error", "never"],
+        "function-paren-newline": ["error", { "minItems": 2 }],
         "space-before-blocks": ["warn", "always"],
         "brace-style": ["warn", "1tbs", { "allowSingleLine": true }],
         "object-curly-spacing": ["warn", "always", { "arraysInObjects": false }],


### PR DESCRIPTION
Will format this:

```ts
const extractAccountIdFromPayload = async (paymentProvider: SettlementProvider, allObjects: ParsedAttachment[]): Promise<string | undefined> => {
    return `hithere ${paymentProvider} ${allObjects}`;
};
```

to this:

```ts
const extractAccountIdFromPayload = async (
    paymentProvider: SettlementProvider, allObjects: ParsedAttachment[]
): Promise<string | undefined> => {
    return `hithere ${paymentProvider} ${allObjects}`;
};
```

and this:

```ts
const normalMap = async (email: ParsedMail,
    paymentProvider: SettlementProvider,
    emailDate: Date,
    originKey: string,
): Promise<SettlementFiles[]> => {
    return [];
};
```

to this:

```ts
const normalMap = async (
    email: ParsedMail,
    paymentProvider: SettlementProvider,
    emailDate: Date,
    originKey: string,
): Promise<SettlementFiles[]> => {
    return [];
};
```

https://eslint.org/docs/rules/function-paren-newline