### PR TITLE
Allow non-null-assertion

### DIFF
--- a/typescript.js
+++ b/typescript.js
@@ -32,6 +32,7 @@ module.exports = {
         "@typescript-eslint/explicit-module-boundary-types":  "off",
         "@typescript-eslint/ban-ts-comment": "off",
         "@typescript-eslint/no-use-before-define": "off",
+        "@typescript-eslint/no-non-null-assertion": "off",
 
         "@typescript-eslint/member-delimiter-style": ["error", { "multiline": { "delimiter": "none" }, "singleline": { "delimiter": "comma" } }],
         "@typescript-eslint/type-annotation-spacing": ["error", { "before": false, "after": true, "overrides": { "arrow": { "before": true, "after": true }} }],


### PR DESCRIPTION
Typescript isn't always able to detect non nullish checks, and sometimes you know for a fact that a value is non-nullish (if it is, that may be a case where you want a hard crash).
It's prefered to treat a value as non-nullish by using `!` instead of `as any` or `as unknown as T`, so I suggest disabling this rule from `@typescript-eslint/recommended`. Use with care however, it is a good idea to always check for non-nullish.