### PR TITLE
Allow unused function args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 package-lock.json
+.idea/

--- a/default.js
+++ b/default.js
@@ -2,7 +2,7 @@ module.exports = {
     rules: {
         //"dot-notation": "off",
         "eol-last": ["error", "always"],
-        "no-unused-vars": ["warn", { "args": "none" }],
+        "no-unused-vars": ["warn", { "args": "none",  "ignoreRestSiblings": true }],
         "prefer-const": "warn",
         "prefer-spread": "warn",
         "no-duplicate-imports": "error",

--- a/default.js
+++ b/default.js
@@ -2,7 +2,7 @@ module.exports = {
     rules: {
         //"dot-notation": "off",
         "eol-last": ["error", "always"],
-        "no-unused-vars": "warn",
+        "no-unused-vars": ["warn", { "args": "none" }],
         "prefer-const": "warn",
         "prefer-spread": "warn",
         "no-duplicate-imports": "error",

--- a/typescript.js
+++ b/typescript.js
@@ -33,7 +33,7 @@ module.exports = {
         "@typescript-eslint/ban-ts-comment": "off",
         "@typescript-eslint/no-use-before-define": "off",
         "@typescript-eslint/no-non-null-assertion": "off",
-        "@typescript-eslint/no-unused-vars": ["warn", { "args": "none" }],
+        "@typescript-eslint/no-unused-vars": ["warn", { "args": "none",  "ignoreRestSiblings": true }],
 
         "@typescript-eslint/member-delimiter-style": ["error", { "multiline": { "delimiter": "none" }, "singleline": { "delimiter": "comma" } }],
         "@typescript-eslint/type-annotation-spacing": ["error", { "before": false, "after": true, "overrides": { "arrow": { "before": true, "after": true }} }],

--- a/typescript.js
+++ b/typescript.js
@@ -33,6 +33,7 @@ module.exports = {
         "@typescript-eslint/ban-ts-comment": "off",
         "@typescript-eslint/no-use-before-define": "off",
         "@typescript-eslint/no-non-null-assertion": "off",
+        "@typescript-eslint/no-unused-vars": ["warn", { "args": "none" }],
 
         "@typescript-eslint/member-delimiter-style": ["error", { "multiline": { "delimiter": "none" }, "singleline": { "delimiter": "comma" } }],
         "@typescript-eslint/type-annotation-spacing": ["error", { "before": false, "after": true, "overrides": { "arrow": { "before": true, "after": true }} }],


### PR DESCRIPTION
https://eslint.org/docs/rules/no-unused-vars#args

Adding

"no-unused-vars": ["warn", { "args": "none" }]
 "@typescript-eslint/no-unused-vars": ["warn", { "args": "none" }],

Allows unused function arguments. I've found this to be legitimate in many cases:

- Express error middleware requires that you set all arguments (basically due to bad design)
- Passing a callback to a library / other places, and documenting which arguments are available