### PR TITLE
Update peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,12 @@
 {
     "name": "eslint-config-dintero",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "description": "EsLint configuration for Dintero",
     "main": "backend.js",
     "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": "^2 || ^3 || ^4 || ^5",
-        "@typescript-eslint/parser": "^2 || ^3 || ^4 || ^5",
+        "@typescript-eslint/eslint-plugin": "^2 || ^3 || ^4 || ^5 || ^6",
+        "@typescript-eslint/parser": "^2 || ^3 || ^4 || ^5 || ^6",
         "eslint": "^6 || ^7 || ^8",
-        "eslint-config-react-app": "^5 || ^6 || ^7",
-        "eslint-plugin-react": "^7",
-        "typescript": "^3 || ^4"
+        "typescript": "3 || ^4 || ^5"
     }
 }


### PR DESCRIPTION
Remove peer dependencies on `eslint-config-react-app and `eslint-plugin-react`
as they are only needed when using react config

Updated peer dependencies to support newer versions of eslint and
typescript
